### PR TITLE
Load balancing final review sync as pr

### DIFF
--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -9,6 +9,8 @@ require "logstash/plugin_mixins/http_client"
 require "logstash/plugin_mixins/validator_support/required_host_optional_port_validation_adapter"
 require "zlib"
 
+require "stud/interval" # Stud::stoppable_sleep
+
 class LogStash::Outputs::Logstash < LogStash::Outputs::Base
   extend LogStash::PluginMixins::ValidatorSupport::RequiredHostOptionalPortValidationAdapter
 

--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -65,11 +65,11 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
       "Content-Encoding" => "gzip".freeze
     }.freeze
 
-    logger.debug("`logstash` output plugin has been initialized.")
+    logger.debug("`logstash` output plugin has been initialized")
   end
 
   def register
-    logger.debug("Registering `logstash` output plugin.")
+    logger.debug("Registering `logstash` output plugin")
 
     @username = normalize_config(:username) do |normalize|
       normalize.with_deprecated_alias(:user)
@@ -93,29 +93,29 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
 
     @load_balancer = LoadBalancer.new(normalize_host_uris)
 
-    logger.debug("`logstash` output plugin has been registered.")
+    logger.debug("`logstash` output plugin has been registered")
   end
 
   def validate_auth_settings!
     if @username
-      fail(LogStash::ConfigurationError, '`password` is REQUIRED when `username` is provided.') if @password.nil?
-      logger.warn("Transmitting credentials over non-secured connection.") if @ssl_enabled == false
+      fail(LogStash::ConfigurationError, '`password` is REQUIRED when `username` is provided') if @password.nil?
+      logger.warn("Transmitting credentials over non-secured connection") if @ssl_enabled == false
     elsif @password
-      fail(LogStash::ConfigurationError, '`password` not allowed unless `username` is configured.')
+      fail(LogStash::ConfigurationError, '`password` not allowed unless `username` is configured')
     end
   end
 
   def validate_ssl_identity_options!
     if @ssl_certificate && @ssl_keystore_path
-      fail(LogStash::ConfigurationError, "SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both.")
+      fail(LogStash::ConfigurationError, "SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both")
     elsif @ssl_certificate
-      fail(LogStash::ConfigurationError, "`ssl_key` is REQUIRED when `ssl_certificate` is provided.") if @ssl_key.nil?
+      fail(LogStash::ConfigurationError, "`ssl_key` is REQUIRED when `ssl_certificate` is provided") if @ssl_key.nil?
     elsif @ssl_key
-      fail(LogStash::ConfigurationError, "`ssl_key` is not allowed unless `ssl_certificate` is configured.")
+      fail(LogStash::ConfigurationError, "`ssl_key` is not allowed unless `ssl_certificate` is configured")
     elsif @ssl_keystore_path
-      fail(LogStash::ConfigurationError, "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided.") if @ssl_keystore_password.nil?
+      fail(LogStash::ConfigurationError, "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided") if @ssl_keystore_password.nil?
     elsif @ssl_keystore_password
-      fail(LogStash::ConfigurationError, "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured.")
+      fail(LogStash::ConfigurationError, "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured")
     else
       # acceptable
     end
@@ -123,14 +123,14 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
 
   def validate_ssl_trust_options!
     if @ssl_certificate_authorities&.any? && @ssl_truststore_path
-      fail(LogStash::ConfigurationError, "SSL trust can be configured with EITHER `ssl_certificate_authorities` OR `ssl_truststore_*`, but not both.")
+      fail(LogStash::ConfigurationError, "SSL trust can be configured with EITHER `ssl_certificate_authorities` OR `ssl_truststore_*`, but not both")
     elsif @ssl_certificate_authorities&.any?
-      fail(LogStash::ConfigurationError, "SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`.") if @ssl_verification_mode == 'none'
+      fail(LogStash::ConfigurationError, "SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`") if @ssl_verification_mode == 'none'
     elsif @ssl_truststore_path
-      fail(LogStash::ConfigurationError, "SSL Truststore cannot be configured when `ssl_verification_mode => none`.") if @ssl_verification_mode == 'none'
-      fail(LogStash::ConfigurationError, "`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided.") if @ssl_truststore_password.nil?
+      fail(LogStash::ConfigurationError, "SSL Truststore cannot be configured when `ssl_verification_mode => none`") if @ssl_verification_mode == 'none'
+      fail(LogStash::ConfigurationError, "`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided") if @ssl_truststore_password.nil?
     elsif @ssl_truststore_password
-      fail(LogStash::ConfigurationError, "`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured.")
+      fail(LogStash::ConfigurationError, "`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured")
     end
   end
 
@@ -141,13 +141,13 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
   end
 
   def stop
-    logger.debug("`logstash` output plugin has been stopped.")
+    logger.debug("`logstash` output plugin has been stopped")
   end
 
   def close
-    logger.debug("Closing `logstash` output plugin.")
+    logger.debug("Closing `logstash` output plugin")
     http_client.close
-    logger.debug("`logstash` output plugin has been closed.")
+    logger.debug("`logstash` output plugin has been closed")
   end
 
   private
@@ -178,7 +178,7 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
       next_backoff = [next_backoff*2, max_backoff].min
 
       if pipeline_shutdown_requested?
-        logger.warn "Aborting the batch due to shutdown request."
+        logger.warn "Aborting the batch due to shutdown request"
         abort_batch_if_available!
         break # legacy abort (lossy)
       end

--- a/lib/logstash/utils/load_balancer.rb
+++ b/lib/logstash/utils/load_balancer.rb
@@ -3,13 +3,6 @@
 
 require "monitor"
 
-##
-# The following is a high-level validation of CURRENT implementation
-# that is tightly-coupled with initial state and is NOT a specification
-# of the behaviour once its initial state has been invalidated by use.
-#
-# A formal validation of the load balancer's behaviour is forthcoming.
-#
 class LoadBalancer
   include MonitorMixin
 

--- a/spec/unit/load_balancer_spec.rb
+++ b/spec/unit/load_balancer_spec.rb
@@ -4,6 +4,13 @@ require_relative "../spec_helper"
 require "logstash/devutils/rspec/shared_examples"
 require "logstash/utils/load_balancer"
 
+#
+# The following is a high-level validation of CURRENT implementation
+# that is tightly-coupled with initial state and is NOT a specification
+# of the behaviour once its initial state has been invalidated by use.
+#
+# A formal validation of the load balancer's behaviour is forthcoming.
+#
 describe LoadBalancer do
   let(:downstream_infos) { %w[1.1.1.1:9801 2.2.2.2:9802 3.3.3.3:9803] }
 

--- a/spec/unit/logstash_output_spec.rb
+++ b/spec/unit/logstash_output_spec.rb
@@ -70,7 +70,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("username" => "test_user") }
 
         it "requires `password`" do
-          expected_message = "`password` is REQUIRED when `username` is provided."
+          expected_message = "`password` is REQUIRED when `username` is provided"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -79,7 +79,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("password" => "pa$$") }
 
         it "requires `username`" do
-          expected_message = "`password` not allowed unless `username` is configured."
+          expected_message = "`password` not allowed unless `username` is configured"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -105,7 +105,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_certificate" => cert_fixture!('server_from_root.pem')) }
 
         it "requires `ssl_key`" do
-          expected_message = "`ssl_key` is REQUIRED when `ssl_certificate` is provided."
+          expected_message = "`ssl_key` is REQUIRED when `ssl_certificate` is provided"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
 
@@ -113,7 +113,7 @@ describe LogStash::Outputs::Logstash do
           let(:config) { super().merge("ssl_keystore_path" => cert_fixture!("client_from_root.jks"), "ssl_key" => cert_fixture!("server_from_root.key.pem")) }
 
           it "cannot be used together" do
-            expected_message = "SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both."
+            expected_message = "SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both"
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
           end
         end
@@ -123,7 +123,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_key" => cert_fixture!('server_from_root.key.pkcs8.pem')) }
 
         it "requires SSL certificate" do
-          expected_message = '`ssl_key` is not allowed unless `ssl_certificate` is configured.'
+          expected_message = '`ssl_key` is not allowed unless `ssl_certificate` is configured'
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -132,7 +132,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_keystore_path" => cert_fixture!('server_from_root.jks')) }
 
         it "requires `ssl_keystore_password`" do
-          expected_message = "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided."
+          expected_message = "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -141,7 +141,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_keystore_password" => "pa$$w0rd") }
 
         it "requires `ssl_keystore_path`" do
-          expected_message = "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured."
+          expected_message = "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -157,7 +157,7 @@ describe LogStash::Outputs::Logstash do
           let(:config) { super().merge("ssl_verification_mode" => "none") }
 
           it "not allowed" do
-            expected_message = "SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`."
+            expected_message = "SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`"
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
           end
         end
@@ -166,7 +166,7 @@ describe LogStash::Outputs::Logstash do
           let(:config) { super().merge("ssl_truststore_path" => cert_fixture!("client_self_signed.jks")) }
 
           it "not allowed" do
-            expected_message = "SSL trust can be configured with EITHER `ssl_certificate_authorities` OR `ssl_truststore_*`, but not both."
+            expected_message = "SSL trust can be configured with EITHER `ssl_certificate_authorities` OR `ssl_truststore_*`, but not both"
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
           end
         end
@@ -176,7 +176,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_truststore_path" => cert_fixture!('client_self_signed.jks')) }
 
         it "requires truststore password" do
-          expected_message = "`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided."
+          expected_message = "`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
 
@@ -184,7 +184,7 @@ describe LogStash::Outputs::Logstash do
           let(:config) { super().merge("ssl_verification_mode" => "none") }
 
           it "not allowed" do
-            expected_message = "SSL Truststore cannot be configured when `ssl_verification_mode => none`."
+            expected_message = "SSL Truststore cannot be configured when `ssl_verification_mode => none`"
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
           end
         end
@@ -194,7 +194,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_truststore_password" => "pa$$w0rd") }
 
         it "not allowed" do
-          expected_message = "`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured."
+          expected_message = "`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured"
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end


### PR DESCRIPTION
I had a couple comment threads that got lost or mis-applied, so I thought it would be easiest to just drop a PR:

 - [revert addition of trailing punctuation to log messages](https://github.com/logstash-plugins/logstash-integration-logstash/pull/16#discussion_r1380632313)
 - [replace commentary about spec on spec instead of implementation](https://github.com/logstash-plugins/logstash-integration-logstash/pull/16#discussion_r1380551651)
 - adds a require to the stud internals needed, since they aren't reliably available when running specs (even though they are certainly already available when running inside of a Logstash process).